### PR TITLE
fix a typo

### DIFF
--- a/Wsl_cheat_sheet.txt
+++ b/Wsl_cheat_sheet.txt
@@ -11,7 +11,7 @@ wsl ––status                       #Mostrar distro por defecto y versión
 Gestión de distribuciones
 
 wsl --list --online                                  #Listar distros en remoto para instalar
-wsl --list --distribution <nombre_Distro>            #Instalar distribución online
+wsl --install --distribution <nombre_Distro>            #Instalar distribución online
 wsl --list --v                                       #Lista distros instaladas y estado
 wsl --set-version <nombre_Distro> <version>          #Cambiar de versión de WSL una distro (reversible)    
 wsl --set-default-version <version>                  #Cambiar de versión por defecto para todas las distribuciones


### PR DESCRIPTION
This pull request includes a small change to the `Wsl_cheat_sheet.txt` file. The change corrects the command for installing a distribution online.

* [`Wsl_cheat_sheet.txt`](diffhunk://#diff-b75e10917238057a69af008721aacbf90cc7cb3ca7dc70fe749a90cd40309a19L14-R14): Changed `wsl --list --distribution <nombre_Distro>` to `wsl --install --distribution <nombre_Distro>` to accurately reflect the command for installing a distribution online.